### PR TITLE
change gamemode automatically

### DIFF
--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -9,8 +9,9 @@ MapVoteConfigDefault = {
     EnableCooldown = true,
     MapsBeforeRevote = 3,
     RTVPlayerCount = 3,
-    MapPrefixes = {"ttt_"}
-    }
+    MapPrefixes = {"ttt_"},
+    AutoGamemode = true
+}
 --Default Config
 
 hook.Add( "Initialize", "MapVoteConfigSetup", function()


### PR DESCRIPTION
This adds the ability to automatically change the gamemode when a map is selected, which is useful if you have two or more gamemodes available (such as TTT and deathrun for example).

The gamemode is detected based on the map prefix and the map prefix patterns defined by the available gamemodes.

_I know that the last change was done in 2014 but I think that this could be useful to share since the plugin is still used by many others._